### PR TITLE
Change SCRIPT_ADDRESS type prefix

### DIFF
--- a/NBitcoin.Litecoin/LitecoinNetworks.cs
+++ b/NBitcoin.Litecoin/LitecoinNetworks.cs
@@ -116,7 +116,7 @@ namespace NBitcoin.Litecoin
 				GetPoWHash = GetPoWHash
 			})
 			.SetBase58Bytes(Base58Type.PUBKEY_ADDRESS, new byte[] { 48 })
-			.SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] { 50 })
+			.SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] { 5 })
 			.SetBase58Bytes(Base58Type.SECRET_KEY, new byte[] { 176 })
 			.SetBase58Bytes(Base58Type.EXT_PUBLIC_KEY, new byte[] { 0x04, 0x88, 0xB2, 0x1E })
 			.SetBase58Bytes(Base58Type.SECRET_KEY, new byte[] { 0x04, 0x88, 0xAD, 0xE4 })
@@ -159,7 +159,7 @@ namespace NBitcoin.Litecoin
 				GetPoWHash = GetPoWHash
 			})
 			.SetBase58Bytes(Base58Type.PUBKEY_ADDRESS, new byte[] { 111 })
-			.SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] { 58 })
+			.SetBase58Bytes(Base58Type.SCRIPT_ADDRESS, new byte[] { 196 })
 			.SetBase58Bytes(Base58Type.SECRET_KEY, new byte[] { 239 })
 			.SetBase58Bytes(Base58Type.EXT_PUBLIC_KEY, new byte[] { 0x04, 0x35, 0x87, 0xCF })
 			.SetBase58Bytes(Base58Type.SECRET_KEY, new byte[] { 0x04, 0x35, 0x83, 0x94 })


### PR DESCRIPTION
I've changed the values for the original values in the litecoin [chainparams.cpp file](https://github.com/litecoin-project/litecoin/blob/master/src/chainparams.cpp#L128). The values used previously here are the ones are new and were introduced in Litecoin in Jun 14 2017 https://github.com/litecoin-project/litecoin/commit/3b03f2cc3009383111ab381a5ed625e895c6aad7

This change is important IMO because otherwise it doesn't pass the test vector for base58 here: https://github.com/litecoin-project/litecoin/blob/master/src/test/data/base58_keys_valid.json